### PR TITLE
Fix typo in env var name

### DIFF
--- a/postinst.sh
+++ b/postinst.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-. $GALAXY_VIRTUALENV/bin/activate
+. $GALAXY_VIRTUAL_ENV/bin/activate
 pip install bcbio-gff biopython


### PR DESCRIPTION
Hi,
I get some errors about a missing BCBio module when galaxy tries to load some of the apollo tools. It seems to come from this tiny typo
