### PR TITLE
New jbrowse tool + default values for env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,10 @@ RUN git clone https://github.com/galaxy-genome-annotation/galaxy-tools /tmp/gala
 ADD fix_perms.sh /bin/fix_perms
 ADD fix_perms.conf /etc/supervisor/conf.d/apollo.conf
 
-ENV GALAXY_WEBAPOLLO_URL http://apollo:8080/apollo
-ENV GALAXY_WEBAPOLLO_USER admin@local.host
-ENV GALAXY_WEBAPOLLO_PASSWORD password
-ENV GALAXY_WEBAPOLLO_EXT_URL /apollo
-ENV GALAXY_SHARED_DIR /apollo-data
-ENV GALAXY_JBROWSE_SHARED_DIR /jbrowse/data
-ENV GALAXY_JBROWSE_SHARED_URL /jbrowse
+ENV GALAXY_WEBAPOLLO_URL="http://apollo:8080/apollo" \
+    GALAXY_WEBAPOLLO_USER="admin@local.host" \
+    GALAXY_WEBAPOLLO_PASSWORD=password \
+    GALAXY_WEBAPOLLO_EXT_URL="/apollo" \
+    GALAXY_SHARED_DIR="/apollo-data" \
+    GALAXY_JBROWSE_SHARED_DIR="/jbrowse/data" \
+    GALAXY_JBROWSE_SHARED_URL="/jbrowse"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,28 @@ ENV GALAXY_CONFIG_TOOL_CONFIG_FILE /galaxy-central/config/tool_conf.xml.sample,/
 ADD welcome.html $GALAXY_CONFIG_DIR/web/welcome.html
 
 # Mark folders as imported from the host.
-VOLUME ["/export/", "/apollo-data/", "/var/lib/docker"]
+VOLUME ["/export/", "/apollo-data/", "/jbrowse/data/", "/var/lib/docker"]
 
 ADD postinst.sh /bin/postinst
 RUN postinst && \
-    chmod 777 /apollo-data
+    chmod 777 /apollo-data && \
+    chmod 777 /jbrowse/data
 
 RUN git clone https://github.com/TAMU-CPT/galaxy-apollo tools/apollo && \
     cd tools/apollo && \
     git checkout 4ac38d0b6dba1183f3e78eb5c224c7051064b4a5
 
+RUN git clone https://github.com/galaxy-genome-annotation/galaxy-tools /tmp/galaxy-tools/ && \
+    cp -RT /tmp/galaxy-tools/tools/ tools/ && \
+    rm -rf /tmp/galaxy-tools/
+
 ADD fix_perms.sh /bin/fix_perms
 ADD fix_perms.conf /etc/supervisor/conf.d/apollo.conf
+
+ENV GALAXY_WEBAPOLLO_URL http://apollo:8080/apollo
+ENV GALAXY_WEBAPOLLO_USER admin@local.host
+ENV GALAXY_WEBAPOLLO_PASSWORD password
+ENV GALAXY_WEBAPOLLO_EXT_URL /apollo
+ENV GALAXY_SHARED_DIR /apollo-data
+ENV GALAXY_JBROWSE_SHARED_DIR /jbrowse/data
+ENV GALAXY_JBROWSE_SHARED_URL /jbrowse

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ Installed tools
 
  * [JBrowse-in-Galaxy](https://github.com/galaxyproject/tools-iuc/tree/master/tools/jbrowse)
  * [Apollo Webservices](https://github.com/TAMU-CPT/galaxy-webapollo)
+ * [Other specific tools](https://github.com/galaxy-genome-annotation/galaxy-tools)
+
+Environment variables
+=====================
+
+The following environment variables must be set:
+
+ENV                           | Use
+---                           | ---
+ `$GALAXY_WEBAPOLLO_URL`      | The URL at which Apollo is accessible, internal to Galaxy and where the tools run. Must be absolute, with FQDN and protocol. (default: http://apollo:8080/apollo)
+ `$GALAXY_WEBAPOLLO_USER`     | The admin user which Galaxy should use to talk to Apollo. (default: admin@local.host)
+ `$GALAXY_WEBAPOLLO_PASSWORD` | The password for the admin user. (default: password)
+ `$GALAXY_WEBAPOLLO_EXT_URL`  | The external URL at which Apollo is accessible to end users. May be relative or absolute. (default: /apollo)
+ `$GALAXY_SHARED_DIR`         | Directory shared between Galaxy and Apollo, used to exchange JBrowse instances. (default: /apollo-data)
+ `$GALAXY_JBROWSE_SHARED_DIR` | Directory shared between Galaxy and JBrowse, used to exchange JBrowse datasets. (default: /jbrowse/data)
+ `$GALAXY_JBROWSE_SHARED_URL` | The external URL at which JBrowse is accessible to end users. May be relative or absolute. (default: /jbrowse)
 
 Users & Passwords
 ================
@@ -78,4 +94,4 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR

--- a/fix_perms.sh
+++ b/fix_perms.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 while true; do
     chmod 777 -R /apollo-data/
+    chmod 777 -R /jbrowse/data/
     sleep 60;
 done;

--- a/tool_conf.xml
+++ b/tool_conf.xml
@@ -8,4 +8,7 @@
         <tool file="apollo/json2iframe.xml" />
         <tool file="apollo/list_organisms.xml" />
     </section>
+    <section id="jbrowse" name="JBrowse">
+        <tool file="jbrowse/jbrowse_to_container.xml" />
+    </section>
 </toolbox>


### PR DESCRIPTION
Hej,

A little PR to add the new jbrowse_to_container tool + updated IUC jbrowse tools.

I also added some default values for the apollo and jbrowse specific env vars, based on the defaults at https://github.com/galaxy-genome-annotation/dockerized-gmod-deployment.

I open this PR now, but it can wait for galaxy-genome-annotation/galaxy-tools/pull/2 to be closed with no problem